### PR TITLE
remove extra forward slash

### DIFF
--- a/404.html
+++ b/404.html
@@ -13,8 +13,8 @@ permalink: /404.html
 		<p>Welcome to the adventure!  It looks like the page you're looking for can't be found.</p>
 		<p>Here are some pages you might be interested in:</p>
 		<ul>
-			<li><a href="{{site.url}}/blog">A Listing of All Articles</a></li>
-			<li><a href="{{site.url}}/our-story">The Story of McKinney Party of 5</a></li>
+			<li><a href="{{site.url}}blog">A Listing of All Articles</a></li>
+			<li><a href="{{site.url}}our-story">The Story of McKinney Party of 5</a></li>
 		</ul>
 	</div>
 	<div class="row">


### PR DESCRIPTION
Currently, links on page have an extra forward slash: https://mckinneypartyof5.life//blog.

This removes the extra slash.